### PR TITLE
Make get_data a 1 liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,37 +76,6 @@ print(my_class.render())
 }
 ```
 
-**Simple scss group**
-
-```py
-my_first_scss_group = SCSS_GROUP("first_scss_group")
-
-my_class = SCSS_CLASS(
-    name="my_class",
-    color="red",
-    position="relative",
-)
-my_class_2 = SCSS_CLASS(
-    name="my_class_2",
-    color="red",
-    position="relative",
-)
-
-my_first_scss_group.add(my_class)
-my_first_scss_group.relationship(my_class, child=my_class_2)
-```
-
-```
-.my_class{
- color:red;
- position:relative;
-
-.my_class_2{
- color:red;
- position:relative;
-}}
-
-```
 
 --------------
 

--- a/slobypy/react/context.py
+++ b/slobypy/react/context.py
@@ -32,13 +32,9 @@ class Context(Generic[T]):
             if context_data := self.get_data():
                 setattr(component, "context", context_data)
 
-    def get_data(self) -> list[T]:
+    def get_data(self) -> list[dict[str, T]]:
         """Used to load the data from the create_data"""
-        context_data: list[T] = []
-        for data in self.create_data():
-            context_data.append(data)
-
-        return context_data
+        return list(self.create_data())
 
     def _check_component_type(self, component: Any) -> TypeGuard[cmp.Component]:
         if not isinstance(component, cmp.Component):


### PR DESCRIPTION
### Changes
- Fixed return annotation for `get_data`.
- Simplified `get_data` logic to a single line.